### PR TITLE
Correct Centos platform name

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -9,8 +9,7 @@
     branch: master
     build-node: centos7-builder-2c-1g
     platforms:
-      - centos
-      - ubuntu-16.04
+      - centos-7
 
     templates: builder
 


### PR DESCRIPTION
In addition remove platform referencing Ubuntu.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>