### PR TITLE
Add sigul ENV vars

### DIFF
--- a/jenkins-config/global-vars-production.sh
+++ b/jenkins-config/global-vars-production.sh
@@ -4,4 +4,6 @@ GIT_URL=https://github.com
 JENKINS_HOSTNAME=vex-yul-odpi-jenkins-prod-1
 LOGS_SERVER=https://logs.odpi.org
 NEXUS_URL=https://nexus.odpi.org
+SIGUL_BRIDGE_IP=10.30.88.9
+SIGUL_KEY=odpi-release-2018
 SILO=production

--- a/jenkins-config/global-vars-sandbox.sh
+++ b/jenkins-config/global-vars-sandbox.sh
@@ -4,4 +4,6 @@ GIT_URL=https://github.com
 JENKINS_HOSTNAME=vex-yul-odpi-jenkins-sandbox-1
 LOGS_SERVER=https://logs.odpi.org
 NEXUS_URL=https://nexus.odpi.org
+SIGUL_BRIDGE_IP=10.30.88.9
+SIGUL_KEY=odpi-sandbox
 SILO=sandbox


### PR DESCRIPTION
To allow the Jenkins environments to use sigul we need some ENV vars
defined globally in Jenkins

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>