### PR TITLE
Adjust egeria project name

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: egeria
-    project-name: egeria
+    project-name: odpi-egeria
     project: egeria
     mvn-settings: egeria-settings
     archive-artifacts: ''


### PR DESCRIPTION
This changes it to match the application id set in Sonar.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>