### PR TITLE
Turn on signing of artifacts

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -12,6 +12,7 @@
           branch: master
     jobs:
       - '{project-name}-github-maven-jobs'
+    sign-artifacts: true
 
 - project:
     name: egeria-sonar


### PR DESCRIPTION
ODPi wishes to have their artifacts released to Maven Central. The first
requirement for this is to enable signing. There will be a follow up
later to enable artifact uploads to Maven Central's staging system.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>