### PR TITLE
Enable Maven Central staging

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -21,5 +21,5 @@
     mvn-staging-id: staging
     mvn-snapshot-id: snapshot
     nexus-snapshot-repo: snapshots
-    mvn-central: true
-    ossrh-profile-id: 56dff43ca17820
+    mvn_central: true
+    ossrh_profile_id: 56dff43ca17820

--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -13,6 +13,8 @@
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true
+    mvn-central: '{mvn_central}'
+    ossrh-profile-id: '{ossrh_profile_id}'
 
 - project:
     name: egeria-sonar


### PR DESCRIPTION
Make sure that Maven Central staging components are enabled.

JJB is not picking up the defaults or some reason, so we're modifying
the default variable names to get access back

Part of fix for #43

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>