### PR TITLE
Add jobs for jdk8 and jdk11

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -10,6 +10,9 @@
     stream:
       - 'master':
           branch: master
+    java-version:
+      - 'openjdk8'
+      - 'openjdk11'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true
@@ -27,6 +30,9 @@
     stream:
       - 'master':
           branch: master
+    java-version:
+      - 'openjdk8'
+      - 'openjdk11'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

Add jobs for jdk8 and jdk11 for project odpi-egeria, egeria-connector-ibm-igc
Modify jenkins-config/clouds/openstack/Primary/cloud.cfg with latest image.

#62 