### PR TITLE
Skip java 11 verify build job

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -12,7 +12,6 @@
           branch: master
     java-version:
       - 'openjdk8'
-      - 'openjdk11'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true
@@ -32,7 +31,6 @@
           branch: master
     java-version:
       - 'openjdk8'
-      - 'openjdk11'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#62 

Skip java 11 verify build as its depend on the global-jjb new-feature to be released which will create unique status-context for each build job of java8 and java11. Currently its creating the same status context for both in github which is creating the confusion. 