### PR TITLE
Remove java version

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -10,8 +10,6 @@
     stream:
       - 'master':
           branch: master
-    java-version:
-      - 'openjdk8'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true
@@ -29,8 +27,6 @@
     stream:
       - 'master':
           branch: master
-    java-version:
-      - 'openjdk8'
     jobs:
       - '{project-name}-github-maven-jobs'
     sign-artifacts: true


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#82 

Due to adding the multiple java version in the project template, global-jjb java builds - 'odpi-egeria-maven-stage-master', 'odpi-egeria-maven-merge-master', 'odpi-egeria-maven-clm-master' are getting failed as they are passing wrong Environment variables.

To Fix this need modifications in the global-jjb. Till that time we are removing the java-version from the project template and using only openjdk8 version.
