### PR TITLE
Add Sonarcloud token for scanning

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -23,3 +23,7 @@
     nexus-snapshot-repo: snapshots
     mvn_central: true
     ossrh_profile_id: 56dff43ca17820
+
+    # Sonarcloud
+    sonarcloud_project_organization: odpi
+    sonarcloud_api_token: a62308f92d67ddcefc1196c305b8ed418efd1c2b

--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -45,6 +45,11 @@
     jobs:
       - github-maven-sonar
 
+    sonarcloud: true
+    sonarcloud-project-organization: '{sonarcloud_project_organization}'
+    sonarcloud-project-key: odpi_egeria
+    sonarcloud-api-token: '{sonarcloud_api_token}'
+
 - project:
     name: 'egeria-maven-clm'
     project-name: 'odpi-egeria'


### PR DESCRIPTION
Add the needed bits to reconfigure Jenkins to use SonarCloud for
scanning.

Issue: #77
Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>