### PR TITLE
Add maven-goal as clean deploy -DskipFVT to verify job

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -11,7 +11,11 @@
       - 'master':
           branch: master
     jobs:
-      - '{project-name}-github-maven-jobs'
+      - github-maven-clm
+      - github-maven-merge
+      - github-maven-stage
+      - github-maven-verify:
+          mvn-goals: 'clean deploy -DskipFVT'
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#78 

As per the Thanh inputs,  using local job-group to override the maven-goal params for verify job   