### PR TITLE
Add new minion centos7-docker-4c-4g.cfg for docker jobs

### DIFF
--- a/jenkins-config/clouds/openstack/Primary/centos7-docker-4c-4g.cfg
+++ b/jenkins-config/clouds/openstack/Primary/centos7-docker-4c-4g.cfg
@@ -1,0 +1,2 @@
+IMAGE_NAME=ZZCI - CentOS 7 - docker - x86_64 - 20190417-182736.971
+HARDWARE_ID=v2-standard-4


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#100 

For docker jobs in the odpi egeria adding new docker template in  jenkins cloud config.
Which will be used for executing docker jobs.