### PR TITLE
Add support to openjdk8 and openjdk11 in maven verify jobs

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -18,6 +18,9 @@
       - github-maven-stage
       - github-maven-verify:
           mvn-goals: 'clean deploy -DskipFVT'
+          java-version:
+              - 'openjdk8'
+              - 'openjdk11'
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#62 

Add openjdk11 to verify job and it will be non-blocking for PR for now.
