### PR TITLE
Downgrade Packer version to 1.3.5

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -7,6 +7,7 @@
     project: ci-management
     project-name: ci-management
     branch: master
+    packer-version: 1.3.5
     build-node: centos7-builder-2c-1g
     platforms:
       - centos-7


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#44 

Observed that, if I build docker builder using Packer version 1.4.0 my docker Image creation job is getting failed.  And if I create the build docker builder using Packer version 1.3.5 the n docker Image creation job is Success.. 

So changing the Packer version to 1.3.5 for now.