### PR TITLE
add_java_opts_to Sonar_Job

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -33,7 +33,9 @@
     archive-artifacts: ''
     build-node: centos7-builder-4c-4g
     cron: '@daily'
+    mvn-params: '-DfindBugs -sonar.java.spotbugs.reportPaths="target/spotbugsXml.xml" -Dsonar.java.pmd.reportPaths="target/pmd.xml"'
     mvn-opts: '-Xmx2048m'
+    java-opts: '-Xmx5120m'
     jobs:
       - github-maven-sonar
 


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

#120 

While running the sonar job with out java_opts is failing since during runtime the pmd/spotbug scan consumes more memory. Any way the mvn-opts are not working out to fix the issue. We added java-option to sonarjob global jjb.