### PR TITLE
Fix ranger builder after egeria directory rename

### DIFF
--- a/jjb/egeria/egeria-docker.yaml
+++ b/jjb/egeria/egeria-docker.yaml
@@ -38,7 +38,7 @@
       - github-maven-docker-stage:
           project-name: egeria-ranger
           mvn-goals: 'clean install'
-          mvn-params: '-Ddocker -Ddocker.repo=odpi -Ddockerfile.useMavenSettingsForAuth=true -f open-metadata-resources/open-metadata-deployment/docker/ranger/'
+          mvn-params: '-Ddocker -Ddocker.repo=odpi -Ddockerfile.useMavenSettingsForAuth=true -f open-metadata-resources/open-metadata-deployment/docker/apache-ranger-admin/'
 
 - project:
     name: maven-docker-views


### PR DESCRIPTION
FAO @schannamallu 

In egeria the directories have been renamed for the ranger docker image
See https://github.com/odpi/egeria/issues/1372

Please could you merge and kick off to verify (I can't test myself?)

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>