### PR TITLE
remove the package version

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -7,7 +7,6 @@
     project: ci-management
     project-name: ci-management
     branch: master
-    packer-version: 1.3.5
     build-node: centos7-builder-2c-1g
     platforms:
       - centos-7


### PR DESCRIPTION
Signed-off-by: Suresh Channamallu <schannamallu@linuxfoundation.org>

Remove the package version from local jjb and relay on global jjb packer version