### PR TITLE
Disable Docker Jobs

### DIFF
--- a/jjb/egeria/egeria-docker.yaml
+++ b/jjb/egeria/egeria-docker.yaml
@@ -2,6 +2,7 @@
 - project:
     name: egeria-docker
     project: egeria
+    disable-job: true
     mvn-settings: egeria-settings
     archive-artifacts: ''
     build-node: centos7-docker-4c-4g


### PR DESCRIPTION
These have been switched over to publish from AZP. Disabling them so
Jenkins does not overwrite the containers being published and we're no
longer able to trace where the builds come from.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>