### PR TITLE
Disable Sonar Jobs

### DIFF
--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -32,6 +32,7 @@
     project: egeria
     mvn-settings: egeria-settings
     archive-artifacts: ''
+    disable-job: true
     build-node: centos7-builder-4c-4g
     cron: '@daily'
     mvn-params: '-DfindBugs -sonar.java.spotbugs.reportPaths="target/spotbugsXml.xml" -Dsonar.java.pmd.reportPaths="target/pmd.xml"'


### PR DESCRIPTION
These have been transitioned over to Azure Pipelines and do not need to
be run from multiple places.

Relates to odpi/egeria#1690
Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>