### PR TITLE
Disable CLM Jobs for Egeria and Connectors

### DIFF
--- a/jjb/egeria/egeria-connector-apache-atlas.yaml
+++ b/jjb/egeria/egeria-connector-apache-atlas.yaml
@@ -12,7 +12,11 @@
       - 'master':
           branch: master
     jobs:
-      - '{project-name}-github-maven-jobs'
+      - github-maven-clm:
+          disable-job: true
+      - github-maven-merge
+      - github-maven-stage
+      - github-maven-verify
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'

--- a/jjb/egeria/egeria-connector-ibm-igc.yaml
+++ b/jjb/egeria/egeria-connector-ibm-igc.yaml
@@ -12,7 +12,11 @@
       - 'master':
           branch: master
     jobs:
-      - '{project-name}-github-maven-jobs'
+      - github-maven-clm:
+          disable-job: true
+      - github-maven-merge
+      - github-maven-stage
+      - github-maven-verify
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'

--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -14,7 +14,8 @@
       - 'egeria-release-1.0':
           branch: 'egeria-release-1.0'
     jobs:
-      - github-maven-clm
+      - github-maven-clm:
+          disable-job: true
       - github-maven-merge
       - github-maven-stage
       - github-maven-verify:


### PR DESCRIPTION
These have been transitioned to Azure Pipelines.

Relates to odpi/egeria#1652 and odpi/egeria#1707
Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>