### PR TITLE
Disable Verify and Stage Egeria Jobs

### DIFF
--- a/jjb/egeria/egeria-connector-apache-atlas.yaml
+++ b/jjb/egeria/egeria-connector-apache-atlas.yaml
@@ -15,8 +15,10 @@
       - github-maven-clm:
           disable-job: true
       - github-maven-merge
-      - github-maven-stage
-      - github-maven-verify
+      - github-maven-stage:
+          disable-job: true
+      - github-maven-verify:
+          disable-job: true
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'

--- a/jjb/egeria/egeria-connector-ibm-igc.yaml
+++ b/jjb/egeria/egeria-connector-ibm-igc.yaml
@@ -15,8 +15,10 @@
       - github-maven-clm:
           disable-job: true
       - github-maven-merge
-      - github-maven-stage
-      - github-maven-verify
+      - github-maven-stage:
+          disable-job: true
+      - github-maven-verify:
+          disable-job: true
     sign-artifacts: true
     mvn-central: '{mvn_central}'
     ossrh-profile-id: '{ossrh_profile_id}'

--- a/jjb/egeria/egeria.yaml
+++ b/jjb/egeria/egeria.yaml
@@ -17,8 +17,10 @@
       - github-maven-clm:
           disable-job: true
       - github-maven-merge
-      - github-maven-stage
+      - github-maven-stage:
+          disable-job: true
       - github-maven-verify:
+          disable-job: true
           mvn-goals: 'clean deploy -DskipFVT'
           java-version:
               - 'openjdk8'


### PR DESCRIPTION
The verify and merge jobs have been running on Azure now without an
issue, and releases are now done through Azure Release Pipelines.

Relates to odpi/egeria#1652

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>